### PR TITLE
CASMINST-6050 Create RPM packaging for goss

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,0 +1,54 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+@Library('csm-shared-library') _
+
+def isStable = (env.TAG_NAME != null)
+
+pipeline {
+    agent {
+        label "metal-gcp-builder"
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: "10"))
+        timestamps()
+    }
+
+    stages {
+        stage('Build: RPM') {
+            steps {
+                sh 'make -f Makefile.HPE clean all'
+            }
+        }
+
+        stage('Publish') {
+            steps {
+                archiveArtifacts(artifacts: 'release/goss-*', allowEmptyArchive: true)
+                publishCsmRpms(component: "hpe-csm-goss-package", pattern: "release/RPMS/x86_64/*.rpm", arch: "x86_64", isStable: isStable)
+            }
+        }
+    }
+}

--- a/Makefile.HPE
+++ b/Makefile.HPE
@@ -1,0 +1,38 @@
+BUILD_DIR ?= $(PWD)/release
+# bf971d4
+GIT_SHA ?= $(shell git rev-parse --short HEAD)
+# v0.3.21-5-gbf971d4
+GIT_DESCRIBE ?= $(shell git describe --tags)
+# v0.3.21 - may need to override that, for example, if random recent tag chimes in
+GIT_LAST_TAG ?= $(shell git describe --tags --abbrev=0)
+
+# RPM spec always wants non emtpy {VERSION}-{RELEASE} - split last tag into version and release.
+SPEC_VERSION = $(GIT_LAST_TAG:v%=%)
+SPEC_VERSION := $(subst -, ,$(SPEC_VERSION))
+SPEC_RELEASE = $(word 2,$(SPEC_VERSION))
+SPEC_VERSION := $(word 1,$(SPEC_VERSION))
+# If last tag does not have -* suffix, start from hpe1
+ifeq ($(SPEC_RELEASE),)
+	SPEC_RELEASE = hpe1
+endif
+# If not on tag currently, add git SHA to mark unstable build
+ifneq ($(GIT_DESCRIBE),$(GIT_LAST_TAG))
+	SPEC_RELEASE := $(SPEC_RELEASE).g$(GIT_SHA)
+endif
+
+all: test release_alpha_darwin_amd64 release_linux_amd64 rpm_build
+
+clean:
+	make -f Makefile clean
+
+test:
+	make -f Makefile test
+
+release_linux_amd64:
+	TRAVIS_TAG=$(SPEC_VERSION)-$(SPEC_RELEASE) make -f Makefile release/goss-linux-amd64
+
+release_alpha_darwin_amd64:
+	TRAVIS_TAG=$(SPEC_VERSION)-$(SPEC_RELEASE) make -f Makefile release/goss-alpha-darwin-amd64
+
+rpm_build: release_linux_amd64
+	SPEC_VERSION=$(SPEC_VERSION) SPEC_RELEASE=$(SPEC_RELEASE) rpmbuild --nodeps -bb goss.spec --define "_topdir $(BUILD_DIR)"

--- a/goss.spec
+++ b/goss.spec
@@ -1,0 +1,19 @@
+Name: hpe-csm-goss-package
+License: MIT License
+Summary: Goss is a YAML based serverspec alternative tool for validating a servers configuration.
+Version: %(echo ${SPEC_VERSION})
+Release: %(echo ${SPEC_RELEASE})
+Vendor: Hewlett Packard Enterprise Development LP
+Provides: goss
+%description
+Installs the Goss binary onto a Linux system.
+
+%install
+pwd
+mkdir -pv ${RPM_BUILD_ROOT}/usr/bin/
+cp -pv ../goss-linux-amd64 ${RPM_BUILD_ROOT}/usr/bin/goss
+
+%files
+%license ../../LICENSE
+%defattr(755,root,root)
+/usr/bin/goss


### PR DESCRIPTION
Adds RPM packaging. The package name is preserved as `hpe-csm-goss-package` as we have that recorded in many systems and manifests. Additionally, binaries for `linux-amd64` and `darwin-amd64` are stored as Jenkins build artifacts, for local use.

* Resolves [CASMINST-6050](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6050)

Testing:
* tested build locally on MacOS
* tested Jenkinsfile and `linux-amd64` build in Jenkins