### PR TITLE
CASMINST-6052 Add stdout/stderr to junit output

### DIFF
--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/fatih/color"
@@ -35,29 +36,29 @@ func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult,
 		for _, testResult := range resultGroup {
 			m := struct2map(testResult)
 			duration := strconv.FormatFloat(m["duration"].(float64)/1000/1000/1000, 'f', 3, 64)
-			summary[testCount] = "<testcase name=\"" +
+			summary[testCount] = "  <testcase name=\"" +
 				testResult.ResourceType + " " +
 				escapeString(testResult.ResourceId) + " " +
 				testResult.Property + "\" " +
 				"time=\"" + duration + "\">\n"
-			if testResult.Result == resource.FAIL {
-				summary[testCount] += "<system-err>" +
-					escapeString(humanizeResult2(testResult)) +
-					"</system-err>\n"
-				summary[testCount] += "<failure>" +
-					escapeString(humanizeResult2(testResult)) +
-					"</failure>\n</testcase>\n"
-
-				failed++
+			if testResult.Result == resource.SKIP {
+				summary[testCount] += "    <skipped/>\n"
+				skipped++
 			} else {
-				if testResult.Result == resource.SKIP {
-					summary[testCount] += "<skipped/>"
-					skipped++
+				summary[testCount] += "    <system-out>" +
+					escapeString(strings.TrimSpace(testResult.Stdout)) +
+					"</system-out>\n"
+				summary[testCount] += "    <system-err>" +
+					escapeString(strings.TrimSpace(testResult.Stderr)) +
+					"</system-err>\n"
+				if testResult.Result == resource.FAIL {
+					summary[testCount] += "    <failure>" +
+						escapeString(humanizeResult2(testResult)) +
+						"</failure>\n"
+					failed++
 				}
-				summary[testCount] += "<system-out>" +
-					escapeString(humanizeResult2(testResult)) +
-					"</system-out>\n</testcase>\n"
 			}
+			summary[testCount] += "  </testcase>\n"
 			testCount++
 		}
 	}

--- a/resource/validate.go
+++ b/resource/validate.go
@@ -74,6 +74,8 @@ type TestResult struct {
 	Found        []string       `json:"found" yaml:"found"`
 	Human        string         `json:"human" yaml:"human"`
 	Duration     time.Duration  `json:"duration" yaml:"duration"`
+	Stdout       string         `json:"stdout" yaml:"stdout"`
+	Stderr       string         `json:"stderr" yaml:"stderr"`
 }
 
 // ToOutcome converts the enum to a human-friendly string.


### PR DESCRIPTION
There is a RFE for upstream goss to add stdout/stderr to test output, but it is not implemented (marked for v4):
https://github.com/goss-org/goss/issues/483

I think we can add this functionality to internal build of goss at least for junit output. This format is used by CSM vShasta automation. Having stdout/stderr in Junit XML would simplify troubleshooting.

JIRA: [CASMINST-6052](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6052)

Testing:
* Tested locally to ensure that junit output contains stderr/stdout:
      
      $ GOSS_USE_ALPHA=1 release/goss-alpha-darwin-amd64 --gossfile testdata/passing.goss.yaml validate --format junit
      <?xml version="1.0" encoding="UTF-8"?>
      <testsuite name="goss" errors="0" tests="2" failures="0" skipped="0" time="0.006" timestamp="2023-03-07T11:58:51-08:00">
        <testcase name="Command hello world exit-status" time="0.000">
          <system-out>hello world</system-out>
          <system-err></system-err>
        </testcase>
        <testcase name="Command hello world stdout" time="0.000">
          <system-out>hello world</system-out>
          <system-err></system-err>
        </testcase>
      </testsuite>

      $ GOSS_USE_ALPHA=1 release/goss-alpha-darwin-amd64 --gossfile testdata/failing.goss.yaml validate --format junit
      <?xml version="1.0" encoding="UTF-8"?>
      <testsuite name="goss" errors="0" tests="2" failures="2" skipped="0" time="0.007" timestamp="2023-03-07T11:59:18-08:00">
        <testcase name="Command hello world exit-status" time="0.000">
          <system-out>hello world</system-out>
          <system-err></system-err>
          <failure>Command: hello world: exit-status: doesn&#39;t match, expect: [1] found: [0]</failure>
        </testcase>
        <testcase name="Command hello world stdout" time="0.000">
          <system-out>hello world</system-out>
          <system-err></system-err>
          <failure>Command: hello world: stdout: patterns not found: [did not echo this]</failure>
        </testcase>
      </testsuite>

* Unit tests are passing locally and in CICD