### PR TITLE
CASMINST-3421 Remove dependency on sle-15sp2

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -37,6 +37,10 @@ pipeline {
         timestamps()
     }
 
+    environment {
+        NAME = 'hpe-csm-goss-package'
+    }
+
     stages {
         stage('Build: RPM') {
             steps {
@@ -50,7 +54,27 @@ pipeline {
         stage('Publish') {
             steps {
                 archiveArtifacts(artifacts: 'release/goss-*', allowEmptyArchive: true)
-                publishCsmRpms(component: "hpe-csm-goss-package", pattern: "release/RPMS/x86_64/*.rpm", arch: "x86_64", isStable: isStable)
+                publishCsmRpms(
+                        component: "${env.NAME}",
+                        os: 'sle-15sp2',
+                        pattern: "release/RPMS/x86_64/*.rpm",
+                        arch: "x86_64",
+                        isStable: isStable
+                )
+                publishCsmRpms(
+                        component: "${env.NAME}",
+                        os: 'sle-15sp4',
+                        pattern: "release/RPMS/x86_64/*.rpm",
+                        arch: "x86_64",
+                        isStable: isStable
+                )
+                publishCsmRpms(
+                        component: "${env.NAME}",
+                        os: 'noos',
+                        pattern: "release/RPMS/x86_64/*.rpm",
+                        arch: "x86_64",
+                        isStable: isStable
+                )
             }
         }
     }

--- a/Makefile.HPE
+++ b/Makefile.HPE
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 BUILD_DIR ?= $(PWD)/release
 # bf971d4
 GIT_SHA ?= $(shell git rev-parse --short HEAD)

--- a/goss.spec
+++ b/goss.spec
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 Name: hpe-csm-goss-package
 License: MIT License
 Summary: Goss is a YAML based serverspec alternative tool for validating a servers configuration.


### PR DESCRIPTION
This package is the last package we pull into image builds that comes from an old SP2 repo.

To facilitate CASMINST-3421, publish this to `noos` and `sle-15sp4`. The former is for CASMINST-3421, the latter is to prevent breaking things that haven't added the `noos` repo yet.
